### PR TITLE
fix: tolerate non-conforming extra whitespace between SDP fields

### DIFF
--- a/lib/detekt-baseline.xml
+++ b/lib/detekt-baseline.xml
@@ -5,8 +5,8 @@
     <ID>ConstructorParameterNaming:CandidateAttribute.kt$CandidateAttribute$internal var _extensions: MutableMap&lt;String, String></ID>
     <ID>ConstructorParameterNaming:SdpMediaDescription.kt$SdpMediaDescription$private var _protos: MutableList&lt;String></ID>
     <ID>ConstructorParameterNaming:WithParametersAttribute.kt$WithParametersAttribute$internal open var _parameters: MutableMap&lt;String, Any?> = linkedMapOf()</ID>
-    <ID>CyclomaticComplexMethod:SdpSessionDescription.kt$SdpSessionDescription.Companion$fun parse(text: String): SdpSessionDescription</ID>
-    <ID>LongMethod:SdpSessionDescription.kt$SdpSessionDescription.Companion$fun parse(text: String): SdpSessionDescription</ID>
+    <ID>CyclomaticComplexMethod:SdpSessionDescription.kt$SdpSessionDescription.Companion$private fun parseWithContext(text: String): SdpSessionDescription</ID>
+    <ID>LongMethod:SdpSessionDescription.kt$SdpSessionDescription.Companion$private fun parseWithContext(text: String): SdpSessionDescription</ID>
     <ID>ThrowsCount:CandidateAttribute.kt$CandidateAttribute.Companion$internal fun parse(value: String): SdpAttribute</ID>
     <ID>ThrowsCount:RTPMapAttribute.kt$RTPMapAttribute.Companion$internal fun parse(value: String): SdpAttribute</ID>
     <ID>ThrowsCount:SdpOrigin.kt$SdpOrigin.Companion$internal fun parse(line: String): SdpOrigin</ID>

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpConnection.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpConnection.kt
@@ -1,6 +1,7 @@
 package io.github.crow_misia.sdp
 
 import io.github.crow_misia.sdp.Utils.appendSdpLineSeparator
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 /**
  * RFC 8866 5.7. Connection Information.
@@ -49,8 +50,9 @@ data class SdpConnection internal constructor(
             return SdpConnection(nettype, addrtype, connectionAddress, ttl, numberOfAddresses)
         }
 
+        context(_: SdpParseContext)
         internal fun parse(line: String): SdpConnection {
-            val values = line.substring(2).split(' ')
+            val values = line.substring(2).splitOnSpaces()
             if (values.size != 3) {
                 throw SdpParseException("could not parse: $line as Connection")
             }

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpMediaDescription.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpMediaDescription.kt
@@ -3,6 +3,7 @@
 package io.github.crow_misia.sdp
 
 import io.github.crow_misia.sdp.Utils.appendSdpLineSeparator
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 import io.github.crow_misia.sdp.attribute.MidAttribute
 import io.github.crow_misia.sdp.attribute.SdpAttribute
 
@@ -95,8 +96,9 @@ data class SdpMediaDescription internal constructor(
                 attributes = ArrayList(attributes))
         }
 
+        context(_: SdpParseContext)
         internal fun parse(line: String): SdpMediaDescription {
-            val values = line.substring(2).split(' ', limit = 4)
+            val values = line.substring(2).splitOnSpaces(limit = 4)
             if (values.size != 4) {
                 throw SdpParseException("could not parse: $line as MediaDescription")
             }
@@ -116,7 +118,7 @@ data class SdpMediaDescription internal constructor(
                 numberOfPorts = numberOfPorts,
                 information = null,
                 _protos = values[2].splitToSequence('/').toMutableList(),
-                formats = values[3].splitToSequence(' ').toMutableList(),
+                formats = values[3].splitOnSpaces().toMutableList(),
                 connections = arrayListOf(),
                 bandwidths = arrayListOf(),
                 attributes = arrayListOf()

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpOrigin.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpOrigin.kt
@@ -1,6 +1,7 @@
 package io.github.crow_misia.sdp
 
 import io.github.crow_misia.sdp.Utils.appendSdpLineSeparator
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 import java.math.BigInteger
 
 /**
@@ -56,8 +57,9 @@ data class SdpOrigin internal constructor(
             )
         }
 
+        context(_: SdpParseContext)
         internal fun parse(line: String): SdpOrigin {
-            val values = line.substring(2).split(' ')
+            val values = line.substring(2).splitOnSpaces()
             if (values.size != 6) {
                 throw SdpParseException("could not parse: $line as Origin")
             }

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpParseContext.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpParseContext.kt
@@ -1,0 +1,71 @@
+package io.github.crow_misia.sdp
+
+/**
+ * Whitespace-handling policy for the positional, `SP`-delimited SDP fields.
+ *
+ * SDP/RFC 4566 and RFC 4570 ABNF require exactly one `SP` between fields, but
+ * real-world producers sometimes emit several. The two policies differ only in
+ * how a run of spaces is treated; everything else about parsing is identical.
+ *
+ * It is threaded through the parsers as a Kotlin context parameter (rather than
+ * an explicit flag on every `parse` function) so that line parsers can simply
+ * call [splitOnSpaces] and the active policy is supplied implicitly.
+ */
+internal interface SdpParseContext {
+    /**
+     * Splits [input] on the inter-field separator, after trimming leading and
+     * trailing spaces.
+     *
+     * [limit] behaves like [String.split]: a positive value caps the number of
+     * returned parts and the final part keeps any remaining separator spaces, so
+     * free-form remainders (fmtp params, crypto session-params, ...) survive
+     * intact.
+     */
+    fun splitOnSpaces(input: String, limit: Int = 0): List<String>
+}
+
+/**
+ * Spec-conforming policy: exactly one `SP` between fields. A non-conforming run
+ * of spaces therefore yields empty tokens, which the per-field arity checks
+ * reject -- so malformed whitespace surfaces as a parse failure rather than
+ * silently misaligned fields. This is the default.
+ */
+internal object StrictSdpContext : SdpParseContext {
+    override fun splitOnSpaces(input: String, limit: Int): List<String> =
+        input.trim().split(' ', limit = limit)
+}
+
+/**
+ * Tolerant policy: collapses runs of `SP` so that producers emitting extra
+ * whitespace (e.g. `a=source-filter: incl IN IP4  239.1.1.1 0.0.0.0`) still
+ * parse with their fields aligned. Implemented as a single forward scan, without
+ * a regular expression.
+ */
+internal object LenientSdpContext : SdpParseContext {
+    override fun splitOnSpaces(input: String, limit: Int): List<String> {
+        val result = mutableListOf<String>()
+        var start = 0
+        var i = 0
+        while (i < input.length) {
+            // Once limit - 1 parts are produced, the rest is one final part.
+            if (limit > 0 && result.size == limit - 1) {
+                break
+            }
+            if (input[i] == ' ') {
+                if (i > start) {
+                    result.add(input.substring(start, i))
+                }
+                while (i < input.length && input[i] == ' ') {
+                    i++
+                }
+                start = i
+            } else {
+                i++
+            }
+        }
+        if (start < input.length) {
+            result.add(input.substring(start))
+        }
+        return result
+    }
+}

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpRepeatTimes.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpRepeatTimes.kt
@@ -3,6 +3,7 @@
 package io.github.crow_misia.sdp
 
 import io.github.crow_misia.sdp.Utils.appendSdpLineSeparator
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 /**
  * RFC 8866 5.10. Repeat Times.
@@ -48,8 +49,9 @@ data class SdpRepeatTimes internal constructor(
             return SdpRepeatTimes(repeatInterval, activeDuration, offsets.toMutableList())
         }
 
+        context(_: SdpParseContext)
         internal fun parse(line: String): SdpRepeatTimes {
-            val values = line.substring(2).split(' ')
+            val values = line.substring(2).splitOnSpaces()
             val size = values.size
             if (size < 3) {
                 throw SdpParseException("could not parse: $line as RepeatTime")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpSessionDescription.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpSessionDescription.kt
@@ -331,7 +331,23 @@ data class SdpSessionDescription internal constructor(
             )
         }
 
-        fun parse(text: String): SdpSessionDescription {
+        /**
+         * Parses [text] into an [SdpSessionDescription].
+         *
+         * By default ([strict] = true) the positional fields must be separated
+         * by exactly one `SP`, per RFC 4566 / 4570; non-conforming runs of
+         * spaces are rejected. Pass [strict] = false to tolerate extra
+         * whitespace by collapsing runs of `SP`.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun parse(text: String, strict: Boolean = true): SdpSessionDescription {
+            val context: SdpParseContext = if (strict) StrictSdpContext else LenientSdpContext
+            return with(context) { parseWithContext(text) }
+        }
+
+        context(_: SdpParseContext)
+        private fun parseWithContext(text: String): SdpSessionDescription {
             var version: SdpVersion? = null
             var origin: SdpOrigin? = null
             var sessionName: SdpSessionName? = null

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpTimeActive.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpTimeActive.kt
@@ -1,6 +1,7 @@
 package io.github.crow_misia.sdp
 
 import io.github.crow_misia.sdp.Utils.appendSdpLineSeparator
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 /**
  * RFC 8866 5.9. Time Active.
@@ -35,8 +36,9 @@ data class SdpTimeActive internal constructor(
             return SdpTimeActive(startTime, stopTime, repeatTime)
         }
 
+        context(_: SdpParseContext)
         internal fun parse(line: String): SdpTimeActive {
-            val values = line.substring(2).split(' ')
+            val values = line.substring(2).splitOnSpaces()
             if (values.size != 2) {
                 throw SdpParseException("could not parse: $line as Timing")
             }

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpTimeZones.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/SdpTimeZones.kt
@@ -3,6 +3,7 @@
 package io.github.crow_misia.sdp
 
 import io.github.crow_misia.sdp.Utils.appendSdpLineSeparator
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 /**
  * RFC 8866 5.11. Time Zone Adjustment.
@@ -35,8 +36,9 @@ data class SdpTimeZones internal constructor(
             return SdpTimeZones(timeZones.toMutableList())
         }
 
+        context(_: SdpParseContext)
         internal fun parse(line: String): SdpTimeZones {
-            val values = line.substring(2).split(' ')
+            val values = line.substring(2).splitOnSpaces()
             val size = values.size
             if (size % 2 != 0) {
                 throw SdpParseException("could not parse: $line as TimeZones")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/Utils.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/Utils.kt
@@ -6,7 +6,7 @@ import kotlin.math.absoluteValue
 
 @Suppress("NOTHING_TO_INLINE")
 internal object Utils {
-    private val PARSERS: Map<String, (String) -> SdpAttribute> = hashMapOf(
+    private val PARSERS: Map<String, context(SdpParseContext) (String) -> SdpAttribute> = hashMapOf(
         CandidateAttribute.fieldName to { v -> CandidateAttribute.parse(v) },
         CNameAttribute.fieldName to { v -> CNameAttribute.parse(v) },
         ControlAttribute.fieldName to { v -> ControlAttribute.parse(v) },
@@ -78,8 +78,17 @@ internal object Utils {
         this.toLong().toString()
     }
 
-    @JvmStatic
-    fun parseAttribute(line: String): SdpAttribute {
+    /**
+     * Splits the receiver on the inter-field separator using the active
+     * [SdpParseContext] (strict by default, lenient when parsing was started
+     * with `strict = false`). See [SdpParseContext.splitOnSpaces] for [limit].
+     */
+    context(ctx: SdpParseContext)
+    internal fun String.splitOnSpaces(limit: Int = 0): List<String> =
+        ctx.splitOnSpaces(this, limit)
+
+    context(ctx: SdpParseContext)
+    internal fun parseAttribute(line: String): SdpAttribute {
         val colonIndex = line.indexOf(':', 2)
         val (field, value) = if (colonIndex < 0) {
             line.substring(2) to ""
@@ -88,7 +97,7 @@ internal object Utils {
         }
 
         val lowerField = getFieldName(field)
-        return PARSERS[lowerField]?.invoke(value) ?: run {
+        return PARSERS[lowerField]?.invoke(ctx, value) ?: run {
             BaseSdpAttribute.of(lowerField, value)
         }
     }

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/CandidateAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/CandidateAttribute.kt
@@ -2,8 +2,10 @@
 
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
 import io.github.crow_misia.sdp.Utils
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 /**
  * RFC 5245 21.1.1. candidate.
@@ -140,8 +142,9 @@ data class CandidateAttribute internal constructor(
             )
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ')
+            val values = value.splitOnSpaces()
             val size = values.size
             if (size < 6) {
                 throw SdpParseException("could not parse: $value as CandidateAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/CryptoAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/CryptoAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class CryptoAttribute internal constructor(
     var id: Long,
@@ -33,8 +35,9 @@ data class CryptoAttribute internal constructor(
             return CryptoAttribute(id, suite, config, sessionConfig)
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 4)
+            val values = value.splitOnSpaces(limit = 4)
             val size = values.size
             if (size < 3) {
                 throw SdpParseException("could not parse: $value as CryptoAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/ExtMapAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/ExtMapAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class ExtMapAttribute internal constructor(
     var id: Long,
@@ -47,8 +49,9 @@ data class ExtMapAttribute internal constructor(
             return ExtMapAttribute(value, direction, uri, encryptUri, config)
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 4)
+            val values = value.splitOnSpaces(limit = 4)
             val size = values.size
             if (size < 2) {
                 throw SdpParseException("could not parse: $value as ExtMapAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/FingerprintAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/FingerprintAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class FingerprintAttribute internal constructor(
     var type: String,
@@ -25,8 +27,9 @@ data class FingerprintAttribute internal constructor(
             return FingerprintAttribute(type.trim(), hash.trim())
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 2)
+            val values = value.splitOnSpaces(limit = 2)
             val size = values.size
             if (size != 2) {
                 throw SdpParseException("could not parse: $value as FingerprintAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/FmtpAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/FmtpAttribute.kt
@@ -2,7 +2,9 @@
 
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 /**
  * RFC8866 6.15. fmtp (Format Parameters)
@@ -42,8 +44,9 @@ data class FmtpAttribute internal constructor(
             }
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): FmtpAttribute {
-            val values = value.split(' ', limit = 2)
+            val values = value.splitOnSpaces(limit = 2)
             val size = values.size
             if (size < 1) {
                 throw SdpParseException("could not parse: $value as FormatAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/GroupAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/GroupAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class GroupAttribute internal constructor(
     var type: String,
@@ -32,15 +34,16 @@ data class GroupAttribute internal constructor(
             return GroupAttribute(type, mids.toMutableList())
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 2)
+            val values = value.splitOnSpaces(limit = 2)
             val size = values.size
             if (size < 2) {
                 throw SdpParseException("could not parse: $value as GroupsAttribute")
             }
             return GroupAttribute(
                 type = values[0],
-                mids = values[1].split(' ').toMutableList()
+                mids = values[1].splitOnSpaces().toMutableList()
             )
         }
     }

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/ImageAttrsAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/ImageAttrsAttribute.kt
@@ -1,7 +1,9 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
 import io.github.crow_misia.sdp.Utils
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 import java.util.*
 import kotlin.math.max
 
@@ -46,8 +48,9 @@ data class ImageAttrsAttribute internal constructor(
             return ImageAttrsAttribute(pt, Utils.getName(dir1), attrs1, dir2?.lowercase(Locale.ENGLISH), attrs2)
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ')
+            val values = value.splitOnSpaces()
             val size = values.size
             if (size < 3) {
                 throw SdpParseException("could not parse: $value as ImageAttrsAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/MsidSemanticAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/MsidSemanticAttribute.kt
@@ -1,5 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
+
 data class MsidSemanticAttribute internal constructor(
     var semantic: String,
     var token: String,
@@ -25,8 +28,9 @@ data class MsidSemanticAttribute internal constructor(
             return MsidSemanticAttribute(semantic, token.orEmpty())
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.trimStart().split(' ', limit = 2)
+            val values = value.splitOnSpaces(limit = 2)
             return MsidSemanticAttribute(values[0], if (values.size > 1) values[1] else "")
         }
     }

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/RTCPAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/RTCPAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class RTCPAttribute internal constructor(
     var port: Int,
@@ -38,8 +40,9 @@ data class RTCPAttribute internal constructor(
             return RTCPAttribute(port, nettype, addrtype, address)
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 4)
+            val values = value.splitOnSpaces(limit = 4)
             val port = values[0].toIntOrNull() ?: run {
                 throw SdpParseException("could not parse: $value as RtcpAttribute")
             }

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/RTCPFbAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/RTCPFbAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class RTCPFbAttribute internal constructor(
     var payloadType: String,
@@ -30,8 +32,9 @@ data class RTCPFbAttribute internal constructor(
             return RTCPFbAttribute(payloadType, type, subtype)
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 3)
+            val values = value.splitOnSpaces(limit = 3)
             val size = values.size
             if (size < 2) {
                 throw SdpParseException("could not parse: $value as RtcpFbAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/RTPMapAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/RTPMapAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 /**
  * RFC8866 6.6. rtpmap
@@ -62,8 +64,9 @@ data class RTPMapAttribute internal constructor(
             )
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 2)
+            val values = value.splitOnSpaces(limit = 2)
             val size = values.size
             if (size < 2) {
                 throw SdpParseException("could not parse: $value as RTPMapAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/RidAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/RidAttribute.kt
@@ -2,7 +2,9 @@
 
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class RidAttribute internal constructor(
     var id: String,
@@ -31,8 +33,9 @@ data class RidAttribute internal constructor(
             }
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 3)
+            val values = value.splitOnSpaces(limit = 3)
             val size = values.size
             if (size < 2) {
                 throw SdpParseException("could not parse: $value as RidAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SctpMapAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SctpMapAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class SctpMapAttribute internal constructor(
     var sctpmapNumber: Int,
@@ -30,8 +32,9 @@ data class SctpMapAttribute internal constructor(
             return SctpMapAttribute(sctpmapNumber, app, maxMessageSize)
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 3)
+            val values = value.splitOnSpaces(limit = 3)
             val size = values.size
             if (size < 2) {
                 throw SdpParseException("could not parse: $value as SctpMapAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SimulcastAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SimulcastAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class SimulcastAttribute internal constructor(
     var dir1: StreamDirection,
@@ -39,11 +41,12 @@ data class SimulcastAttribute internal constructor(
             return SimulcastAttribute(dir1, list1, dir2, list2)
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
             if (value.startsWith(' ')) {
                 return Simulcast03Attribute.of(value.substring(1))
             }
-            val values = value.split(' ', limit = 4)
+            val values = value.splitOnSpaces(limit = 4)
             val size = values.size
             if (size < 2) {
                 throw SdpParseException("could not parse: $value as SimulcastAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SourceFilterAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SourceFilterAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class SourceFilterAttribute internal constructor(
     var filterMode: String,
@@ -53,8 +55,9 @@ data class SourceFilterAttribute internal constructor(
             return SourceFilterAttribute(filterMode, netType, addressTypes, destAddress, srcAddress.toMutableSet())
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.trimStart().split(' ')
+            val values = value.splitOnSpaces()
             val size = values.size
             if (size < 4) {
                 throw SdpParseException("could not parse: $value as SourceFilterAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SsrcAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SsrcAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class SsrcAttribute internal constructor(
     var id: Long,
@@ -30,8 +32,9 @@ data class SsrcAttribute internal constructor(
             return SsrcAttribute(id, attribute, ssrcValue.orEmpty())
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 2)
+            val values = value.splitOnSpaces(limit = 2)
             val size = values.size
             if (size < 2) {
                 throw SdpParseException("could not parse: $value as SsrcAttribute")

--- a/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SsrcGroupAttribute.kt
+++ b/lib/src/main/kotlin/io/github/crow_misia/sdp/attribute/SsrcGroupAttribute.kt
@@ -1,6 +1,8 @@
 package io.github.crow_misia.sdp.attribute
 
+import io.github.crow_misia.sdp.SdpParseContext
 import io.github.crow_misia.sdp.SdpParseException
+import io.github.crow_misia.sdp.Utils.splitOnSpaces
 
 data class SsrcGroupAttribute internal constructor(
     var semantics: String,
@@ -39,13 +41,14 @@ data class SsrcGroupAttribute internal constructor(
             return SsrcGroupAttribute(semantics, ssrcs.toMutableList())
         }
 
+        context(_: SdpParseContext)
         internal fun parse(value: String): SdpAttribute {
-            val values = value.split(' ', limit = 2)
+            val values = value.splitOnSpaces(limit = 2)
             val size = values.size
             if (size < 2) {
                 throw SdpParseException("could not parse: $value as SsrcGroupAttribute")
             }
-            return SsrcGroupAttribute(values[0], values[1].splitToSequence(' ').map { it.toLong() }.toMutableList())
+            return SsrcGroupAttribute(values[0], values[1].splitOnSpaces().map { it.toLong() }.toMutableList())
         }
     }
 }

--- a/lib/src/test/kotlin/io/github/crow_misia/sdp/AbnfLenientWhitespaceTest.kt
+++ b/lib/src/test/kotlin/io/github/crow_misia/sdp/AbnfLenientWhitespaceTest.kt
@@ -1,0 +1,116 @@
+package io.github.crow_misia.sdp
+
+import io.github.crow_misia.sdp.attribute.CandidateAttribute
+import io.github.crow_misia.sdp.attribute.ExtMapAttribute
+import io.github.crow_misia.sdp.attribute.RTCPAttribute
+import io.github.crow_misia.sdp.attribute.SourceFilterAttribute
+import io.github.crow_misia.sdp.attribute.SsrcGroupAttribute
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+/**
+ * RFC 4566/4570 ABNF requires exactly one `SP` between fields, but real-world
+ * payloads sometimes emit runs of spaces. Under the opt-in lenient policy
+ * ([LenientSdpContext], selected by `SdpSessionDescription.parse(text, strict =
+ * false)`) parsing collapses those runs instead of producing empty tokens that
+ * would otherwise misalign positional fields or fail the arity check.
+ *
+ * Strict (the default) behavior is covered by [AbnfStrictWhitespaceTest].
+ */
+class AbnfLenientWhitespaceTest : StringSpec({
+    "source-filter with a double space keeps fields aligned (RFC 4570 regression)" {
+        // a=source-filter: incl IN IP4  239.160.25.253 0.0.0.0  (two spaces after IP4)
+        val actual = with(LenientSdpContext) { SourceFilterAttribute.parse(" incl IN IP4  239.1.1.1 0.0.0.0") }
+        actual shouldBe SourceFilterAttribute.of("incl", "IN", "IP4", "239.1.1.1", "0.0.0.0")
+    }
+
+    "source-filter with extra spaces parses equal to the single-space form" {
+        with(LenientSdpContext) {
+            SourceFilterAttribute.parse("incl   IN  IP4   239.5.2.31    10.1.15.5") shouldBe
+                SourceFilterAttribute.parse("incl IN IP4 239.5.2.31 10.1.15.5")
+        }
+    }
+
+    "origin (o=) tolerates extra spaces" {
+        with(LenientSdpContext) {
+            SdpOrigin.parse("o=jdoe 2890844526  2890842807   IN IP4  10.47.16.5") shouldBe
+                SdpOrigin.parse("o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5")
+        }
+    }
+
+    "connection (c=) tolerates extra spaces" {
+        with(LenientSdpContext) {
+            SdpConnection.parse("c=IN  IP4   224.2.17.12/127") shouldBe
+                SdpConnection.parse("c=IN IP4 224.2.17.12/127")
+        }
+    }
+
+    "timing (t=) tolerates extra spaces" {
+        with(LenientSdpContext) {
+            SdpTimeActive.parse("t=2873397496   2873404696") shouldBe
+                SdpTimeActive.parse("t=2873397496 2873404696")
+        }
+    }
+
+    "rtcp attribute tolerates extra spaces" {
+        with(LenientSdpContext) {
+            RTCPAttribute.parse("65179  IN   IP4  123.45.67.89") shouldBe
+                RTCPAttribute.parse("65179 IN IP4 123.45.67.89")
+        }
+    }
+
+    "extmap attribute tolerates extra spaces between fields" {
+        with(LenientSdpContext) {
+            ExtMapAttribute.parse("3  urn:ietf:params:rtp-hdrext:encrypt   urn:x  25@600/24") shouldBe
+                ExtMapAttribute.parse("3 urn:ietf:params:rtp-hdrext:encrypt urn:x 25@600/24")
+        }
+    }
+
+    "ssrc-group collapses extra spaces in the ssrc list" {
+        val actual = with(LenientSdpContext) { SsrcGroupAttribute.parse("FID 123  456   789") } as SsrcGroupAttribute
+        actual.semantics shouldBe "FID"
+        actual.ssrcs shouldContainExactly listOf(123L, 456L, 789L)
+    }
+
+    "candidate attribute tolerates extra spaces" {
+        with(LenientSdpContext) {
+            CandidateAttribute.parse("0 1 UDP 2113667327  203.0.113.1  54400 typ host") shouldBe
+                CandidateAttribute.parse("0 1 UDP 2113667327 203.0.113.1 54400 typ host")
+        }
+    }
+
+    "leading/trailing spaces around a value are ignored" {
+        with(LenientSdpContext) {
+            SourceFilterAttribute.parse("  incl IN IP4 239.5.2.31 10.1.15.5  ") shouldBe
+                SourceFilterAttribute.parse("incl IN IP4 239.5.2.31 10.1.15.5")
+        }
+    }
+
+    "whole document with sprinkled extra spaces parses equal to the canonical one" {
+        val canonical = """
+            v=0
+            o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5
+            s=SDP Seminar
+            c=IN IP4 224.2.17.12/127
+            t=2873397496 2873404696
+            m=audio 49170 RTP/AVP 0
+            a=rtcp:65179 IN IP4 123.45.67.89
+            a=source-filter: incl IN IP4 239.5.2.31 10.1.15.5
+        """.trimIndent().lines().joinToString("\r\n")
+
+        val spaced = """
+            v=0
+            o=jdoe 2890844526  2890842807 IN IP4  10.47.16.5
+            s=SDP Seminar
+            c=IN  IP4 224.2.17.12/127
+            t=2873397496  2873404696
+            m=audio 49170 RTP/AVP 0
+            a=rtcp:65179  IN IP4  123.45.67.89
+            a=source-filter: incl IN IP4  239.5.2.31 10.1.15.5
+        """.trimIndent().lines().joinToString("\r\n")
+
+        // canonical is conforming, so the default (strict) parse equals the lenient parse of the spaced form.
+        SdpSessionDescription.parse(spaced, strict = false) shouldBe SdpSessionDescription.parse(canonical)
+    }
+})

--- a/lib/src/test/kotlin/io/github/crow_misia/sdp/AbnfStrictWhitespaceTest.kt
+++ b/lib/src/test/kotlin/io/github/crow_misia/sdp/AbnfStrictWhitespaceTest.kt
@@ -1,0 +1,69 @@
+package io.github.crow_misia.sdp
+
+import io.github.crow_misia.sdp.attribute.SourceFilterAttribute
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Strict whitespace handling is the default ([StrictSdpContext]): positional
+ * fields must be separated by exactly one `SP` per RFC 4566/4570. Non-conforming
+ * runs of spaces are not silently repaired -- arity-checked fields reject them,
+ * and others end up misaligned. Callers that need to tolerate extra whitespace
+ * opt in with `strict = false` (see [AbnfLenientWhitespaceTest]).
+ */
+class AbnfStrictWhitespaceTest : StringSpec({
+    val canonical = """
+        v=0
+        o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5
+        s=SDP Seminar
+        c=IN IP4 224.2.17.12/127
+        t=2873397496 2873404696
+        m=audio 49170 RTP/AVP 0
+        a=rtcp:65179 IN IP4 123.45.67.89
+        a=source-filter: incl IN IP4 239.5.2.31 10.1.15.5
+    """.trimIndent().lines().joinToString("\r\n")
+
+    val spaced = """
+        v=0
+        o=jdoe 2890844526  2890842807 IN IP4  10.47.16.5
+        s=SDP Seminar
+        c=IN  IP4 224.2.17.12/127
+        t=2873397496  2873404696
+        m=audio 49170 RTP/AVP 0
+        a=rtcp:65179  IN IP4  123.45.67.89
+        a=source-filter: incl IN IP4  239.5.2.31 10.1.15.5
+    """.trimIndent().lines().joinToString("\r\n")
+
+    "parse is strict by default and accepts conforming input" {
+        // No strict argument -> strict mode; conforming single-SP input parses cleanly.
+        SdpSessionDescription.parse(canonical) shouldBe SdpSessionDescription.parse(canonical, strict = true)
+    }
+
+    "strict (default) rejects a run of spaces between arity-checked fields" {
+        // o= requires exactly 6 fields; the double space yields empty tokens -> reject.
+        shouldThrow<SdpParseException> {
+            SdpSessionDescription.parse(spaced)
+        }
+    }
+
+    "strict origin parse throws on extra spaces" {
+        shouldThrow<SdpParseException> {
+            with(StrictSdpContext) { SdpOrigin.parse("o=jdoe 2890844526  2890842807 IN IP4 10.47.16.5") }
+        }
+    }
+
+    "strict does not repair a non-arity-checked field -- it misaligns" {
+        // source-filter only checks size >= 4, so a double space is not rejected but shifts
+        // the fields right: destAddress becomes "" and the real address leaks into srcList.
+        val misaligned = with(StrictSdpContext) { SourceFilterAttribute.parse("incl IN IP4  239.1.1.1 0.0.0.0") }
+        misaligned shouldNotBe SourceFilterAttribute.of("incl", "IN", "IP4", "239.1.1.1", "0.0.0.0")
+    }
+
+    "strict and lenient agree on conforming input" {
+        val strict = with(StrictSdpContext) { SourceFilterAttribute.parse("incl IN IP4 239.5.2.31 10.1.15.5") }
+        val lenient = with(LenientSdpContext) { SourceFilterAttribute.parse("incl IN IP4 239.5.2.31 10.1.15.5") }
+        strict shouldBe lenient
+    }
+})


### PR DESCRIPTION
SDP/RFC 4566 and RFC 4570 ABNF specify exactly one SP (0x20) as the
separator between positional fields. Real-world producers sometimes emit
runs of spaces, e.g.:

    a=source-filter: incl IN IP4  239.160.25.253 0.0.0.0

(two spaces after IP4). Splitting on a single space turns a run of N
spaces into N-1 empty tokens, which either misaligns positional fields
(source-filter: destAddress becomes "" and the real address leaks into
srcList) or trips an exact-arity check (o= needs 6 tokens, c= needs 3,
...) and drops the line / session.

This change keeps strict, RFC-conforming parsing as the default and adds
an opt-in lenient mode that collapses runs of SP.

Why strict by default
---------------------
Strict is what the spec mandates and what a conformance-sensitive caller
expects: a single SP between fields, with malformed whitespace surfaced
rather than silently repaired. Tolerance is a deliberate, caller-controlled
choice -- not something imposed on every consumer -- so the default rejects
non-conforming input instead of guessing at intent.

Design: a parse context threaded via context parameters
-------------------------------------------------------
The whitespace policy is modeled as an SdpParseContext strategy with two
implementations:

  - StrictSdpContext (default): trims, then splits on a single SP. A run of
    spaces yields empty tokens that the per-field arity checks reject.
  - LenientSdpContext: collapses runs of SP in a single forward scan. The
    limit argument is honored so free-form remainders (fmtp params, crypto
    session-params, ...) are preserved intact. No regex is used.

The active policy is carried through the parsers as a Kotlin context
parameter rather than as an explicit flag on every parse function. The
single public switch is:

    SdpSessionDescription.parse(text, strict = true)

which selects the context and runs the existing parse body inside it;
strict = false opts into lenient. Internally, String.splitOnSpaces and the
per-line / per-attribute parsers gain a `context(SdpParseContext)`
requirement, so the call sites are unchanged and no mode flag is drilled
through them. (Context parameters are a stable language feature as of
Kotlin 2.4, so no compiler flag is required.)

This is not "accept anything": genuinely malformed input (too few tokens,
non-numeric ports, ...) still throws in both modes.

Sites routed through the policy
-------------------------------
  - core fields: o=, c=, t=, r=, z=, m= (including the formats list)
  - attributes: source-filter, candidate, crypto, extmap, fingerprint,
    fmtp, group, imageattr, msid-semantic, rid, rtcp, rtcp-fb, rtpmap,
    sctpmap, simulcast, ssrc, ssrc-group

Tests
-----
  - AbnfStrictWhitespaceTest: strict is the default; an arity-checked field
    (o=) rejects runs of spaces, a non-arity-checked field (source-filter)
    misaligns rather than self-repairs, and both modes agree on conforming
    input.
  - AbnfLenientWhitespaceTest: with strict = false, the RFC 4570
    double-space regression, equal-to-canonical checks for o=/c=/t=, rtcp,
    extmap, candidate and ssrc-group, leading/trailing trim, and a
    whole-document parse with extra spaces sprinkled across line types.

Existing tests and detekt remain green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict and lenient parsing modes for SDP documents. Default strict mode enforces single-space field separation per RFC standards, while lenient mode tolerates extra whitespace. Use `parse(text, strict = false)` to enable lenient parsing.

* **Tests**
  * Added comprehensive test coverage for whitespace handling across strict and lenient parsing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->